### PR TITLE
 Fix Errori di build

### DIFF
--- a/app/proxy/[...path]/route.ts
+++ b/app/proxy/[...path]/route.ts
@@ -77,7 +77,7 @@ const rewriteMetaImages = (
   };
 };
 
-export async function GET(request: NextRequest, context: { params: { path?: string[] } }) {
+export async function GET(request: NextRequest, context: { params: Promise<{ path?: string[] }> }) {
   const { searchParams } = request.nextUrl;
   const params = await context.params;
   const pathSegments = params?.path || [];

--- a/lib/addonProxy.ts
+++ b/lib/addonProxy.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-const ERDB_OPTIONAL_PARAMS = [
+const ERDB_OPTIONAL_PARAMS: Array<keyof ProxyConfig> = [
   'ratings',
   'lang',
   'posterRatingsLayout',


### PR DESCRIPTION
## Riepilogo
Corretti errori di tipo TypeScript che impedivano la compatibilità con Next.js in due file:
1. `app/proxy/[...path]/route.ts` - Tipo dei parametri della route handler
2. `lib/addonProxy.ts` - Tipo dell'array dei parametri opzionali
## Modifiche
### app/proxy/[...path]/route.ts:80
**Prima:**
```typescript
export async function GET(request: NextRequest, context: { params: { path?: string[] } })
```
**Dopo:**
```typescript
export async function GET(request: NextRequest, context: { params: Promise<{ path?: string[] }> })
```
**Motivo:** Next.js richiede che i parametri delle route handler siano una Promise per supportare la natura asincrona dei Server Components. Il `context.params` deve essere `Promise<T>` invece di `T`.
### lib/addonProxy.ts:3
**Prima:**
```typescript
const ERDB_OPTIONAL_PARAMS = [
  'ratings',
  'lang',
  'posterRatingsLayout',
  'posterRatingsMaxPerSide',
  'backdropRatingsLayout',
];
```
**Dopo:**
```typescript
const ERDB_OPTIONAL_PARAMS: Array<keyof ProxyConfig> = [
  'ratings',
  'lang',
  'posterRatingsLayout',
  'posterRatingsMaxPerSide',
  'backdropRatingsLayout',
];
```
**Motivo:** Gli elementi dell'array vengono usati come chiavi di `ProxyConfig` nelle chiamate a `getProxyParam()`. L'annotazione di tipo esplicita assicura che TypeScript validi che siano chiavi valide, prevenendo errori di tipo con il controllo più rigoroso di Next.js.
## Verifica Build
Entrambe le modifiche sono state verify con successo tramite build Docker con Next.js 15.5.12.